### PR TITLE
Better error handling in math_util.c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ matrix:
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.5 SETUP_CMD='test'
 
 before_install:
 

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import
 import os
 import random
 
+from astropy.tests.helper import raises
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_less
 
 from .. import graph
 from .. import great_circle_arc
+from .. import math_util
 from .. import polygon
 from .. import vector
 
@@ -316,3 +319,14 @@ def test_fast_area():
     assert aarea > 0 and aarea < np.pi * 2.0
     assert barea > 0 and barea < np.pi * 2.0
     assert carea > np.pi * 2.0 and carea < np.pi * 4.0
+
+
+@raises(ValueError)
+def test_math_util_angle_domain():
+    # Before a fix, this would segfault
+    math_util.angle([[0, 0, 0]], [[0, 0, 0]], [[0, 0, 0]])
+
+
+@raises(ValueError)
+def test_math_util_length_domain():
+    math_util.length([[np.nan, 0, 0]], [[0, 0, np.inf]])


### PR DESCRIPTION
There were two problems:

- A math domain error would be printed to stderr rather than raised as a
  Python exception.

- Certain domain values actually result in a segfault in qd_library,
  rather than just an error flag as in cstdlib.