### PR TITLE
Second part of fix for polygon.from_cone bug

### DIFF
--- a/spherical_geometry/polygon.py
+++ b/spherical_geometry/polygon.py
@@ -197,7 +197,8 @@ class _SingleSphericalPolygon(object):
             perp = np.cross([u, v, w], [0., 1., 0.])
         else:
             perp = np.cross([u, v, w], [0., 0., 1.])
-
+        perp = vector.normalize_vector(perp)
+        
         # Rotate by radius around the perpendicular vector to get the
         # "pen"
         x, y, z = vector.rotate_around(

--- a/spherical_geometry/src/math_util.c
+++ b/spherical_geometry/src/math_util.c
@@ -134,15 +134,14 @@ normalize_dd(const dd *A, dd *B) {
     c_dd_add(T[0], T[1], T[3]);
     c_dd_add(T[3], T[2], T[3]);
 
-    if (!(T[3][0] == 1.0 && T[3][1] == 0.0)) {
-        if (T[3][0] < -0.0) {
-            PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
-            return 1;
-        }
-        c_dd_sqrt(T[3], l);
-        for (i = 0; i < 3; ++i) {
-            c_dd_div(A[i].x, l, B[i].x);
-        }
+    if (T[3][0] < -0.0) {
+        PyErr_SetString(PyExc_ValueError, "Domain error in sqrt");
+        return 1;
+    }
+    
+    c_dd_sqrt(T[3], l);
+    for (i = 0; i < 3; ++i) {
+        c_dd_div(A[i].x, l, B[i].x);
     }
 
     return 0;

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -27,6 +27,13 @@ def test_normalize_vector():
     l = np.sqrt(np.sum(xyzn * xyzn, axis=-1))
     assert_almost_equal(l, 1.0)
 
+def test_normalize_unit_vector():
+    for i in range(3):
+        xyz = [0.0, 0.0, 0.0]
+        xyz[i] = 1.0
+        xyzn = vector.normalize_vector(xyz)
+        l = np.sqrt(np.sum(xyzn * xyzn, axis=-1))
+        assert_almost_equal(l, 1.0)
 
 def test_radec_to_vector():
     npx, npy, npz = vector.radec_to_vector(np.arange(-360, 360, 1), 90)
@@ -282,14 +289,12 @@ def test_area():
         assert_almost_equal(calc_area, area)
 
 def test_cone_area():
-    dec = 0
     saved_area = None
     for ra in  (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
-        area = polygon.SphericalPolygon.from_cone(ra, dec, 30, steps=64).area()
-        if saved_area:
+        for dec in (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
+            area = polygon.SphericalPolygon.from_cone(ra, dec, 30, steps=64).area()
+            if saved_area is None: saved_area = area 
             assert_almost_equal(area, saved_area)
-        else:
-            saved_area = area
 
 def test_fast_area():
     a = np.array(  # Clockwise


### PR DESCRIPTION
The area of a polygon generated from a cone varies between the cases where both ra and dec of the axis differ from zero from that of a cone and the case where where both ra and dec are zero. This happened because part of the process of generating the cone is generating a unit vector perpendicular to the cone. The vector the code was generating was not always a unit vector and so needed to be normalized. I added a call to vector.normalize_vector to do this. But doing this uncovered a problem in the C version of the code called by normalize_vector. It treated the case where the vector already has unut magnitude as a special case, but provided no code to handle the special case. I have removed the check for the special case. The code could be faster with special case code, but I do not feel confident enough to supply it and it will only be used in a small number of instances. I have also added test cases for both these errors.