### PR TITLE
Modify Area Computation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ before_install:
     - export PYTHONIOENCODING=UTF8
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
+    - ./miniconda.sh -b PREFIX=/home/travis/miniconda2
+    - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda update --yes conda
 
     # UPDATE APT-GET LISTINGS

--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -823,10 +823,8 @@ class Graph:
 
             polygon = mpolygon._SingleSphericalPolygon(points)
             area = polygon.area()
-            reverse_polygon = mpolygon._SingleSphericalPolygon(points[::-1])
-            reverse_area = reverse_polygon.area()
-            if reverse_area < area:
-                polygon = reverse_polygon
+            if area < 0.0:
+                polygon = mpolygon._SingleSphericalPolygon(points[::-1])
             polygons.append(polygon)
 
         return mpolygon.SphericalPolygon(polygons)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -330,9 +330,9 @@ def test_fast_area():
     barea = bpoly.area()
     carea = cpoly.area()
 
-    assert aarea > 0 and aarea < np.pi * 2.0
-    assert barea > 0 and barea < np.pi * 2.0
-    assert carea > np.pi * 2.0 and carea < np.pi * 4.0
+    assert aarea > 0.0 and aarea < 2.0 * np.pi
+    assert barea > 0.0 and barea < 2.0 * np.pi
+    assert carea > -2.0 * np.pi and carea < 0.0
 
 
 @raises(ValueError)


### PR DESCRIPTION
The new version of the code returns a negative area instead of a value between 2 and 4 pi. This will work for most cases of astronomical interest, but will need to be supplemented later to take into account the center point (which is also ignored in the old code.) Some other changes needed to be made because the old code assumed the area was between 0 and 4 pi instead of -2 pi and 2 pi.