### PR TITLE
Add _lonlat calls to code

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -405,7 +405,7 @@ class Graph:
         for polygon in self._source_polygons:
             polygon.draw(m, lw=10, alpha=0.1, color="black")
             v = polygon._points
-            ra, dec = vector.vector_to_radec(v[:, 0], v[:, 1], v[:, 2])
+            ra, dec = vector.vector_to_lonlat(v[:, 0], v[:, 1], v[:, 2])
             x, y = m(ra, dec)
             for x0 in x:
                 minx = min(x0, minx)
@@ -422,19 +422,19 @@ class Graph:
 
         for edge in list(self._edges):
             A, B = [x._point for x in edge._nodes]
-            r0, d0 = vector.vector_to_radec(A[0], A[1], A[2])
-            r1, d1 = vector.vector_to_radec(B[0], B[1], B[2])
+            lon0, lat0 = vector.vector_to_lonlat(A[0], A[1], A[2])
+            lon1, lat1 = vector.vector_to_lonlat(B[0], B[1], B[2])
             if edge is highlight_edge:
                 color = 'red'
                 lw = 2
             else:
                 color = 'blue'
                 lw = 0.5
-            m.drawgreatcircle(r0, d0, r1, d1, color=color, lw=lw)
+            m.drawgreatcircle(lon0, lat0, lon1, lat1, color=color, lw=lw)
 
         for k, v in counts.items():
             v = np.array(v)
-            ra, dec = vector.vector_to_radec(v[:, 0], v[:, 1], v[:, 2])
+            ra, dec = vector.vector_to_lonlat(v[:, 0], v[:, 1], v[:, 2])
             x, y = m(ra, dec)
             m.plot(x, y, 'o', label=str(k))
             for x0 in x:
@@ -446,7 +446,7 @@ class Graph:
 
         for v in intersections:
             if np.all(np.isfinite(v)):
-                ra, dec = vector.vector_to_radec(v[0], v[1], v[2])
+                ra, dec = vector.vector_to_lonlat(v[0], v[1], v[2])
                 x, y = m(ra, dec)
                 m.plot(x, y, 'x', markersize=20)
 

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -35,6 +35,33 @@ def test_normalize_unit_vector():
         l = np.sqrt(np.sum(xyzn * xyzn, axis=-1))
         assert_almost_equal(l, 1.0)
 
+def test_lonlat_to_vector():
+    npx, npy, npz = vector.lonlat_to_vector(np.arange(-360, 360, 1), 90)
+    assert_almost_equal(npx, 0.0)
+    assert_almost_equal(npy, 0.0)
+    assert_almost_equal(npz, 1.0)
+
+    spx, spy, spz = vector.lonlat_to_vector(np.arange(-360, 360, 1), -90)
+    assert_almost_equal(spx, 0.0)
+    assert_almost_equal(spy, 0.0)
+    assert_almost_equal(spz, -1.0)
+
+    eqx, eqy, eqz = vector.lonlat_to_vector(np.arange(-360, 360, 1), 0)
+    assert_almost_equal(eqz, 0.0)
+
+
+def test_vector_to_lonlat():
+    lon, lat = vector.vector_to_lonlat(0, 0, 1)
+    assert_almost_equal(lat, 90)
+
+    lon, lat = vector.vector_to_lonlat(0, 0, -1)
+    assert_almost_equal(lat, -90)
+
+    lon, lat = vector.vector_to_lonlat(1, 1, 0)
+    assert_almost_equal(lon, 45.0)
+    assert_almost_equal(lat, 0.0)
+
+
 def test_radec_to_vector():
     npx, npy, npz = vector.radec_to_vector(np.arange(-360, 360, 1), 90)
     assert_almost_equal(npx, 0.0)
@@ -51,21 +78,21 @@ def test_radec_to_vector():
 
 
 def test_vector_to_radec():
-    ra, dec = vector.vector_to_radec(0, 0, 1)
-    assert_almost_equal(dec, 90)
+    lon, lat = vector.vector_to_radec(0, 0, 1)
+    assert_almost_equal(lat, 90)
 
-    ra, dec = vector.vector_to_radec(0, 0, -1)
-    assert_almost_equal(dec, -90)
+    lon, lat = vector.vector_to_radec(0, 0, -1)
+    assert_almost_equal(lat, -90)
 
-    ra, dec = vector.vector_to_radec(1, 1, 0)
-    assert_almost_equal(ra, 45.0)
-    assert_almost_equal(dec, 0.0)
+    lon, lat = vector.vector_to_radec(1, 1, 0)
+    assert_almost_equal(lon, 45.0)
+    assert_almost_equal(lat, 0.0)
 
 
 def test_intersects_poly_simple():
-    ra1 = [-10, 10, 10, -10, -10]
-    dec1 = [30, 30, 0, 0, 30]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = [-10, 10, 10, -10, -10]
+    lat1 = [30, 30, 0, 0, 30]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
     ra2 = [-5, 15, 15, -5, -5]
     dec2 = [20, 20, -10, -10, 20]
@@ -74,9 +101,9 @@ def test_intersects_poly_simple():
     assert poly1.intersects_poly(poly2)
 
     # Make sure it isn't order-dependent
-    ra1 = ra1[::-1]
-    dec1 = dec1[::-1]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = lon1[::-1]
+    lat1 = lat1[::-1]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
     ra2 = ra2[::-1]
     dec2 = dec2[::-1]
@@ -86,70 +113,70 @@ def test_intersects_poly_simple():
 
 
 def test_intersects_poly_fully_contained():
-    ra1 = [-10, 10, 10, -10, -10]
-    dec1 = [30, 30, 0, 0, 30]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = [-10, 10, 10, -10, -10]
+    lat1 = [30, 30, 0, 0, 30]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = [-5, 5, 5, -5, -5]
-    dec2 = [20, 20, 10, 10, 20]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = [-5, 5, 5, -5, -5]
+    lat2 = [20, 20, 10, 10, 20]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert poly1.intersects_poly(poly2)
 
     # Make sure it isn't order-dependent
-    ra1 = ra1[::-1]
-    dec1 = dec1[::-1]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = lon1[::-1]
+    lat1 = lat1[::-1]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = ra2[::-1]
-    dec2 = dec2[::-1]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = lon2[::-1]
+    lat2 = lat2[::-1]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert poly1.intersects_poly(poly2)
 
 
 def test_hard_intersects_poly():
-    ra1 = [-10, 10, 10, -10, -10]
-    dec1 = [30, 30, 0, 0, 30]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = [-10, 10, 10, -10, -10]
+    lat1 = [30, 30, 0, 0, 30]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = [-20, 20, 20, -20, -20]
-    dec2 = [20, 20, 10, 10, 20]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = [-20, 20, 20, -20, -20]
+    lat2 = [20, 20, 10, 10, 20]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert poly1.intersects_poly(poly2)
 
     # Make sure it isn't order-dependent
-    ra1 = ra1[::-1]
-    dec1 = dec1[::-1]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = lon1[::-1]
+    lat1 = lat1[::-1]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = ra2[::-1]
-    dec2 = dec2[::-1]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = lon2[::-1]
+    lat2 = lat2[::-1]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert poly1.intersects_poly(poly2)
 
 
 def test_not_intersects_poly():
-    ra1 = [-10, 10, 10, -10, -10]
-    dec1 = [30, 30, 5, 5, 30]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = [-10, 10, 10, -10, -10]
+    lat1 = [30, 30, 5, 5, 30]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = [-20, 20, 20, -20, -20]
-    dec2 = [-20, -20, -10, -10, -20]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = [-20, 20, 20, -20, -20]
+    lat2 = [-20, -20, -10, -10, -20]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert not poly1.intersects_poly(poly2)
 
     # Make sure it isn't order-dependent
-    ra1 = ra1[::-1]
-    dec1 = dec1[::-1]
-    poly1 = polygon.SphericalPolygon.from_radec(ra1, dec1)
+    lon1 = lon1[::-1]
+    lat1 = lat1[::-1]
+    poly1 = polygon.SphericalPolygon.from_lonlat(lon1, lat1)
 
-    ra2 = ra2[::-1]
-    dec2 = dec2[::-1]
-    poly2 = polygon.SphericalPolygon.from_radec(ra2, dec2)
+    lon2 = lon2[::-1]
+    lat2 = lat2[::-1]
+    poly2 = polygon.SphericalPolygon.from_lonlat(lon2, lat2)
 
     assert not poly1.intersects_poly(poly2)
 
@@ -203,12 +230,12 @@ def test_great_circle_arc_intersection():
 
     correct = [0.99912414, -0.02936109, -0.02981403]
 
-    A = vector.radec_to_vector(*A)
-    B = vector.radec_to_vector(*B)
-    C = vector.radec_to_vector(*C)
-    D = vector.radec_to_vector(*D)
-    E = vector.radec_to_vector(*E)
-    F = vector.radec_to_vector(*F)
+    A = vector.lonlat_to_vector(*A)
+    B = vector.lonlat_to_vector(*B)
+    C = vector.lonlat_to_vector(*C)
+    D = vector.lonlat_to_vector(*D)
+    E = vector.lonlat_to_vector(*E)
+    F = vector.lonlat_to_vector(*F)
 
     assert great_circle_arc.intersects(A, B, C, D)
     r = great_circle_arc.intersection(A, B, C, D)
@@ -239,20 +266,20 @@ def test_great_circle_arc_intersection():
 def test_great_circle_arc_length():
     A = [90, 0]
     B = [-90, 0]
-    A = vector.radec_to_vector(*A)
-    B = vector.radec_to_vector(*B)
+    A = vector.lonlat_to_vector(*A)
+    B = vector.lonlat_to_vector(*B)
     assert great_circle_arc.length(A, B) == 180.0
 
     A = [135, 0]
     B = [-90, 0]
-    A = vector.radec_to_vector(*A)
-    B = vector.radec_to_vector(*B)
+    A = vector.lonlat_to_vector(*A)
+    B = vector.lonlat_to_vector(*B)
     assert_almost_equal(great_circle_arc.length(A, B), 135.0)
 
     A = [0, 0]
     B = [0, 90]
-    A = vector.radec_to_vector(*A)
-    B = vector.radec_to_vector(*B)
+    A = vector.lonlat_to_vector(*A)
+    B = vector.lonlat_to_vector(*B)
     assert_almost_equal(great_circle_arc.length(A, B), 90.0)
 
 
@@ -268,9 +295,9 @@ def test_great_circle_arc_angle():
 def test_cone():
     random.seed(0)
     for i in range(50):
-        ra = random.randrange(-180, 180)
-        dec = random.randrange(20, 90)
-        cone = polygon.SphericalPolygon.from_cone(ra, dec, 8, steps=64)
+        lon = random.randrange(-180, 180)
+        lat = random.randrange(20, 90)
+        cone = polygon.SphericalPolygon.from_cone(lon, lat, 8, steps=64)
 
 
 def test_area():
@@ -282,7 +309,7 @@ def test_area():
 
     for tri, area in triangles:
         tri = np.array(tri)
-        x, y, z = vector.radec_to_vector(tri[:, 1], tri[:, 0])
+        x, y, z = vector.lonlat_to_vector(tri[:, 1], tri[:, 0])
         points = np.dstack((x, y, z))[0]
         poly = polygon.SphericalPolygon(points)
         calc_area = poly.area()
@@ -290,9 +317,9 @@ def test_area():
 
 def test_cone_area():
     saved_area = None
-    for ra in  (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
-        for dec in (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
-            area = polygon.SphericalPolygon.from_cone(ra, dec, 30, steps=64).area()
+    for lon in  (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
+        for lat in (0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330):
+            area = polygon.SphericalPolygon.from_cone(lon, lat, 30, steps=64).area()
             if saved_area is None: saved_area = area 
             assert_almost_equal(area, saved_area)
 

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -19,13 +19,60 @@ except ImportError:
     HAS_C_UFUNCS = False
 
 
-__all__ = ['radec_to_vector', 'vector_to_radec', 'normalize_vector',
-           'rotate_around']
+__all__ = ['lonlat_to_vector', 'vector_to_lonlat', 'normalize_vector',
+           'radec_to_vector', 'vector_to_radec', 'rotate_around']
+
+
+def lonlat_to_vector(lon, lat, degrees=True):
+    r"""
+    Converts a location on the unit sphere from longitude and
+    latitude to an *x*, *y*, *z* vector.
+
+    Parameters
+    ----------
+    lon, lat : scalars or 1-D arrays
+
+    degrees : bool, optional
+
+       If `True`, (default) *lon* and *lat* are in decimal degrees,
+       otherwise in radians.
+
+    Returns
+    -------
+    x, y, z : tuple of scalars or 1-D arrays of the same length
+
+    Notes
+    -----
+    Where longitude is *l* and latitude is *b*:
+
+    .. math::
+        x = \cos l \cos b
+
+        y = \sin l \cos b
+
+        z = \sin b
+    """
+    lon = np.asanyarray(lon)
+    lat = np.asanyarray(lat)
+
+    if degrees:
+        lon_rad = np.deg2rad(lon)
+        lat_rad = np.deg2rad(lat)
+    else:
+        lon_rad = lon
+        lat_rad = lat
+
+    cos_lat = np.cos(lat_rad)
+
+    return (
+        np.cos(lon_rad) * cos_lat,
+        np.sin(lon_rad) * cos_lat,
+        np.sin(lat_rad))
 
 
 def radec_to_vector(ra, dec, degrees=True):
     r"""
-    Converts a location on the unit sphere from right-ascension and
+    Converts a location on the unit sphere from right ascension and
     declination to an *x*, *y*, *z* vector.
 
     Parameters
@@ -41,38 +88,13 @@ def radec_to_vector(ra, dec, degrees=True):
     -------
     x, y, z : tuple of scalars or 1-D arrays of the same length
 
-    Notes
-    -----
-    Where right-ascension is *α* and declination is *δ*:
-
-    .. math::
-        x = \cos\alpha \cos\delta
-
-        y = \sin\alpha \cos\delta
-
-        z = \sin\delta
     """
-    ra = np.asanyarray(ra)
-    dec = np.asanyarray(dec)
-
-    if degrees:
-        ra_rad = np.deg2rad(ra)
-        dec_rad = np.deg2rad(dec)
-    else:
-        ra_rad = ra
-        dec_rad = dec
-
-    cos_dec = np.cos(dec_rad)
-
-    return (
-        np.cos(ra_rad) * cos_dec,
-        np.sin(ra_rad) * cos_dec,
-        np.sin(dec_rad))
+    return lonlat_to_vector(ra, dec, degrees=degrees)
 
 
-def vector_to_radec(x, y, z, degrees=True):
+def vector_to_lonlat(x, y, z, degrees=True):
     r"""
-    Converts a vector to right-ascension and declination.
+    Converts a vector to longitude and latitude.
 
     Parameters
     ----------
@@ -85,17 +107,16 @@ def vector_to_radec(x, y, z, degrees=True):
 
     Returns
     -------
-    ra, dec : tuple of scalars or arrays of the same length
+    lon, lat : tuple of scalars or arrays of the same length
 
     Notes
     -----
-    Where right-ascension is *α* and declination is
-    *δ*:
+    Where longitude is *l* and latitude is *b*:
 
     .. math::
-        \alpha = \arctan2(y, x)
+        l = \arctan2(y, x)
 
-        \delta = \arctan2(z, \sqrt{x^2 + y^2})
+        b = \arctan2(z, \sqrt{x^2 + y^2})
     """
     x = np.asanyarray(x, dtype=np.float64)
     y = np.asanyarray(y, dtype=np.float64)
@@ -109,6 +130,26 @@ def vector_to_radec(x, y, z, degrees=True):
         return np.rad2deg(result[0]), np.rad2deg(result[1])
     else:
         return result
+
+
+def vector_to_radec(x, y, z, degrees=True):
+    r"""
+    Converts a vector to longitude and latitude.
+
+    Parameters
+    ----------
+    x, y, z : scalars or 1-D arrays
+        The input vectors
+
+    degrees : bool, optional
+        If `True` (default) the result is returned in decimal degrees,
+        otherwise radians.
+
+    Returns
+    -------
+    ra, dec : tuple of scalars or arrays of the same length
+    """
+    return vector_to_lonlat(x, y, z, degrees=degrees)
 
 
 def normalize_vector(xyz, output=None):


### PR DESCRIPTION
This is a fix for issue #42 

SphericalPolygon was written as a general purpose package. However,
function names containing _radec suggested that it has a more limited
purpose. To emphasize the general nature of this package public
function names containing _radec now have _lonlat duals, where _lonlat
stands for longitude and latitude. The _lonlat functions are the more
basic ones, as the _radec functions were rewritten to call the _lonlat
functions. The following functions were added:

    lonlat_to_vector
    vector_to_lonlat
    spherical_polygon.to_lonlat
    SphericalPolygon.from_lonlat

the corresponding duals are still there, to keep from breaking
existing code:

    radec_to_vector
    vector_to_radec
    spherical_polygon.to_radec
    SphericalPolygon.from_radec