### PR TITLE
Change longitude range returned by vector_to_lonlat

### DIFF
--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -61,6 +61,9 @@ def test_vector_to_lonlat():
     assert_almost_equal(lon, 45.0)
     assert_almost_equal(lat, 0.0)
 
+    lon, lat = vector.vector_to_lonlat(1, -1, 0)
+    assert_almost_equal(lon, 315.0)
+    assert_almost_equal(lat, 0.0)
 
 def test_radec_to_vector():
     npx, npy, npz = vector.radec_to_vector(np.arange(-360, 360, 1), 90)
@@ -86,6 +89,10 @@ def test_vector_to_radec():
 
     lon, lat = vector.vector_to_radec(1, 1, 0)
     assert_almost_equal(lon, 45.0)
+    assert_almost_equal(lat, 0.0)
+
+    lon, lat = vector.vector_to_radec(1, -1, 0)
+    assert_almost_equal(lon, 315.0)
     assert_almost_equal(lat, 0.0)
 
 

--- a/spherical_geometry/vector.py
+++ b/spherical_geometry/vector.py
@@ -121,10 +121,13 @@ def vector_to_lonlat(x, y, z, degrees=True):
     x = np.asanyarray(x, dtype=np.float64)
     y = np.asanyarray(y, dtype=np.float64)
     z = np.asanyarray(z, dtype=np.float64)
+    
+    lon = np.arctan2(y, x)
+    if lon < 0.0:
+        lon += np.pi * 2.0
 
-    result = (
-        np.arctan2(y, x),
-        np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
+    lat = np.arctan2(z, np.sqrt(x ** 2 + y ** 2))
+    result = (lon, lat)
 
     if degrees:
         return np.rad2deg(result[0]), np.rad2deg(result[1])


### PR DESCRIPTION
This fix addresses issue #72.

The arctan2 function returns angles in the range -pi to pi, so that
was the range of the longitudes returned by vector_to_lonlat. However,
longitude more normally has the range 0 to 2*pi. So the code now adds
2*pi to the if the longitude is less than zero.