### PR TITLE
Modify the area computation to use inside polygon point

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -821,10 +821,7 @@ class Graph:
                     points.append(node._point)
                     break
 
-            polygon = mpolygon._SingleSphericalPolygon(points)
-            area = polygon.area()
-            if area < 0.0:
-                polygon = mpolygon._SingleSphericalPolygon(points[::-1])
+            polygon = mpolygon._SingleSphericalPolygon(points, auto_orient=True)
             polygons.append(polygon)
 
         return mpolygon.SphericalPolygon(polygons)

--- a/spherical_geometry/tests/test_basic.py
+++ b/spherical_geometry/tests/test_basic.py
@@ -95,7 +95,24 @@ def test_vector_to_radec():
     assert_almost_equal(lon, 315.0)
     assert_almost_equal(lat, 0.0)
 
-
+def test_is_clockwise():
+    clockwise_poly = polygon._SingleSphericalPolygon.from_cone(0.0, 90.0, 1.0)
+    assert clockwise_poly.is_clockwise()
+    
+    outside = [-1.0  * x for x in clockwise_poly.inside]
+    complement_poly = polygon._SingleSphericalPolygon(clockwise_poly.points,
+                                                      inside=outside)
+    assert not complement_poly.is_clockwise()
+    
+    rpoints = clockwise_poly.points[::-1]
+    reverse_poly = polygon._SingleSphericalPolygon(rpoints,
+                                                  inside=clockwise_poly.inside)
+    assert not reverse_poly.is_clockwise()
+    
+    reverse_complement_poly = polygon._SingleSphericalPolygon(rpoints,
+                                                              inside=outside)
+    assert reverse_complement_poly.is_clockwise()
+    
 def test_intersects_poly_simple():
     lon1 = [-10, 10, 10, -10, -10]
     lat1 = [30, 30, 0, 0, 30]

--- a/spherical_geometry/tests/test_intersection.py
+++ b/spherical_geometry/tests/test_intersection.py
@@ -271,7 +271,7 @@ def test_ordering():
         BS = roll_polygon(B, i)
 
         C = AS.intersection(BS)
-
+        
         Aareas.append(A.area())
         Bareas.append(B.area())
         Careas.append(C.area())


### PR DESCRIPTION
The previous area computation assumed that the polygon was smaller
 than a hemisphere (2 pi) and converted the computed area to a negative
 number when larger. The new code looks at the polygon vertices and if
 they are ordered clockwise with respect to the inside point, the area
 is poitive and if they are ordered counter-clockwise, the area is
 negative. This change allows all sizes of polygon to be handled, up to
 4 pi. To support this, a new method, is_clockwise has been added to
 _SingleSphericalPolygon.
    
 I also added auto_close and auto_orient parameters when creating new
 polygon objects. Both are false by default. If auto_close is set to
True, the first point in the polygon is added as the last, closing the
 polygon. If auto_orient is True and the polygon vertices are ordered
 counter-clockwise, the list of vertices is reversed to orient them
 clockwise.
    
 Testing revealed that the computation of the internal point was
 incorrect for the special cose of a triangle, so I rewote that code. I
 also modified the general case to choose the vertex with the sharpest angle.

