### PR TITLE
Add a new step to union computation to remove degenerate edges

### DIFF
--- a/spherical_geometry/graph.py
+++ b/spherical_geometry/graph.py
@@ -477,6 +477,8 @@ class Graph:
         self._sanity_check("union - find all intersections")
         self._remove_interior_edges()
         self._sanity_check("union - remove interior edges")
+        self._remove_degenerate_edges()
+        self._sanity_check("union - remove degenerate edges")
         self._remove_3ary_edges()
         self._sanity_check("union - remove 3ary edges")
         self._remove_orphaned_nodes()
@@ -725,6 +727,19 @@ class Graph:
                 self._remove_edge(edge)
 
         self._remove_orphaned_nodes()
+
+    def _remove_degenerate_edges(self):
+        """
+        Remove edges where both endpoints are the same point
+        """
+        removals = []
+        for edge in list(self._edges):
+            if edge._nodes[0].equals(edge._nodes[1]):
+                removals.append(edge)
+ 
+        for edge in removals:
+            if edge in self._edges:
+                self._remove_edge(edge)
 
     def _remove_3ary_edges(self):
         """


### PR DESCRIPTION
The graph used to compute the union of several polygons can contain
edges where both endpoints are the same. I call these degenerate
edges. These degenerate edges can lead to false positives in the step
which removes 3-connected edges. When edges are removed that shouldn't
be, the result is a disconnected outline for the union. I add a new
step to look for degenerate edges and remove them before calling the
step that removes 3-connected edges,